### PR TITLE
Remove unneeded curl install during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
-      - run: apt-get update
-      - run: apt-get -y install curl
       - checkout
       - run: bash .ci-scripts/install-openssl-0.9.8.bash
       - run: make test config=release
@@ -20,8 +18,6 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
-      - run: apt-get update
-      - run: apt-get -y install curl
       - checkout
       - run: bash .ci-scripts/install-openssl-0.9.8.bash
       - run: make test config=debug


### PR DESCRIPTION
curl is now provided in the ponyc:release image.

Closes #6