### PR TITLE
Automated release process

### DIFF
--- a/.ci-scripts/env.sh
+++ b/.ci-scripts/env.sh
@@ -1,0 +1,8 @@
+REPO_OWNER="ponylang"
+REPO_NAME="crypto"
+GITHUB_USER="ponylang-main"
+
+# Who we are for git
+git config --global user.email "ponylang.main@gmail.com"
+git config --global user.name "Main Pony"
+git config --global push.default simple

--- a/.ci-scripts/release.bash
+++ b/.ci-scripts/release.bash
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+USERNAME="ponylang"
+REPO="crypto"
+GITHUB_USER="ponylang-main"
+
+# Who we are for git
+git config --global user.email "ponylang.main@gmail.com"
+git config --global user.name "Main Pony"
+git config --global push.default simple
+
+# Gather expected arguments.
+if [ $# -lt 2 ]
+then
+  echo "Tag and GH personal access token are required"
+  exit 1
+fi
+
+TAG=$1
+GITHUB_TOKEN=$2
+# changes tag from "release-1.0.0" to "1.0.0"
+VERSION="${TAG/release-/}"
+
+### this doesn't account for master changing commit, assumes we are HEAD
+# or can otherwise push without issue. that shouldl error out without issue.
+# leaving us to restart from a different HEAD commit
+# update CHANGELOG
+changelog-tool release "${VERSION}" -e
+
+# commit CHANGELOG updates
+git add CHANGELOG.md
+git commit -m "Release ${VERSION}"
+
+# tag release
+git tag "${VERSION}"
+
+# push to release to remote
+git push origin HEAD:master "${VERSION}"
+
+# update CHANGELOG for new entries
+changelog-tool unreleased -e
+
+# commit changelog and push to master
+git add CHANGELOG.md
+git commit -m "Add unreleased section to CHANGELOG post ${VERSION} release
+
+[skip ci]"
+git push origin HEAD:master
+
+# release body
+echo "Preparing to update GitHub release notes..."
+
+body=$(changelog-tool get "${VERSION}")
+
+jsontemplate="
+{
+  \"tag_name\":\$version,
+  \"name\":\$version,
+  \"body\":\$body
+}
+"
+
+json=$(jq -n \
+--arg version "$VERSION" \
+--arg body "$body" \
+"${jsontemplate}")
+
+echo "Uploading release notes..."
+
+result=$(curl -X POST "https://api.github.com/repos/${USERNAME}/${REPO}/releases" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "${GITHUB_USER}:${GITHUB_TOKEN}" \
+  --data "${json}")
+
+  rslt_scan=$(echo "${result}" | jq -r '.id')
+if [ "$rslt_scan" != null ]
+then
+  echo "Release notes uploaded"
+else
+  echo "Unable to upload release notes, here's the curl output..."
+  echo "${result}"
+  exit 1
+fi

--- a/.ci-scripts/release.bash
+++ b/.ci-scripts/release.bash
@@ -3,14 +3,7 @@
 set -o errexit
 set -o nounset
 
-REPO_OWNER="ponylang"
-REPO_NAME="crypto"
-GITHUB_USER="ponylang-main"
-
-# Who we are for git
-git config --global user.email "ponylang.main@gmail.com"
-git config --global user.name "Main Pony"
-git config --global push.default simple
+source env.sh
 
 # Gather expected arguments.
 if [ $# -lt 2 ]

--- a/.ci-scripts/release.bash
+++ b/.ci-scripts/release.bash
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-USERNAME="ponylang"
+REPO_OWNER="ponylang"
 REPO="crypto"
 GITHUB_USER="ponylang-main"
 
@@ -70,7 +70,7 @@ json=$(jq -n \
 
 echo "Uploading release notes..."
 
-result=$(curl -X POST "https://api.github.com/repos/${USERNAME}/${REPO}/releases" \
+result=$(curl -X POST "https://api.github.com/repos/${REPO_OWNER}/${REPO}/releases" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "${GITHUB_USER}:${GITHUB_TOKEN}" \
   --data "${json}")

--- a/.ci-scripts/release.bash
+++ b/.ci-scripts/release.bash
@@ -25,8 +25,9 @@ GITHUB_TOKEN=$2
 VERSION="${TAG/release-/}"
 
 ### this doesn't account for master changing commit, assumes we are HEAD
-# or can otherwise push without issue. that shouldl error out without issue.
-# leaving us to restart from a different HEAD commit
+# or can otherwise push without issue. If we aren't, this should error out
+# without issue; leaving us to restart from a different HEAD commit
+
 # update CHANGELOG
 changelog-tool release "${VERSION}" -e
 

--- a/.ci-scripts/release.bash
+++ b/.ci-scripts/release.bash
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 
 REPO_OWNER="ponylang"
-REPO="crypto"
+REPO_NAME="crypto"
 GITHUB_USER="ponylang-main"
 
 # Who we are for git
@@ -71,7 +71,7 @@ json=$(jq -n \
 
 echo "Uploading release notes..."
 
-result=$(curl -X POST "https://api.github.com/repos/${REPO_OWNER}/${REPO}/releases" \
+result=$(curl -X POST "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "${GITHUB_USER}:${GITHUB_TOKEN}" \
   --data "${json}")

--- a/.ci-scripts/upload-release-documentation-to-main-actor.bash
+++ b/.ci-scripts/upload-release-documentation-to-main-actor.bash
@@ -3,7 +3,7 @@
 set -eu
 
 # Needs to be supplied
-USERNAME="ponylang"
+REPO_OWNER="ponylang"
 PACKAGE_NAME="crypto"
 GITHUB_USER="ponylang-main"
 
@@ -33,7 +33,7 @@ DOCS_DIR="${GEN_MD}/${PACKAGE_NAME}/${TAG}"
 # Generated markdown repo
 echo "Cloning main.actor-package-markdown repo into ${GEN_MD}"
 git clone \
-  "https://${GITHUB_TOKEN}@github.com/${USERNAME}/main.actor-package-markdown.git" \
+  "https://${GITHUB_TOKEN}@github.com/${REPO_OWNER}/main.actor-package-markdown.git" \
   "${GEN_MD}"
 
 # Make the docs

--- a/.ci-scripts/upload-release-documentation-to-main-actor.bash
+++ b/.ci-scripts/upload-release-documentation-to-main-actor.bash
@@ -1,16 +1,9 @@
 #!/bin/bash
 
-set -eu
+set -o errexit
+set -o nounset
 
-# Needs to be supplied
-REPO_OWNER="ponylang"
-PACKAGE_NAME="crypto"
-GITHUB_USER="ponylang-main"
-
-# Who we are for git
-git config --global user.email "ponylang.main@gmail.com"
-git config --global user.name "Main Pony"
-git config --global push.default simple
+source env.sh
 
 # Gather expected arguments.
 if [ $# -lt 2 ]

--- a/.ci-scripts/upload-release-documentation-to-main-actor.bash
+++ b/.ci-scripts/upload-release-documentation-to-main-actor.bash
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -eu
+
+# Needs to be supplied
+USERNAME="ponylang"
+PACKAGE_NAME="crypto"
+GITHUB_USER="ponylang-main"
+
+# Who we are for git
+git config --global user.email "ponylang.main@gmail.com"
+git config --global user.name "Main Pony"
+git config --global push.default simple
+
+# Gather expected arguments.
+if [ $# -lt 2 ]
+then
+  echo "Tag and GH personal access token are required"
+  exit 1
+fi
+
+# Directory we are going to do additional work in
+GEN_MD="$(mktemp -d)"
+
+# From command line
+TAG=$1
+GITHUB_TOKEN=$2
+
+# Shouldn't need to touch these
+BUILD_DIR="build/${PACKAGE_NAME}-docs"
+DOCS_DIR="${GEN_MD}/${PACKAGE_NAME}/${TAG}"
+
+# Generated markdown repo
+echo "Cloning main.actor-package-markdown repo into ${GEN_MD}"
+git clone \
+  "https://${GITHUB_TOKEN}@github.com/${USERNAME}/main.actor-package-markdown.git" \
+  "${GEN_MD}"
+
+# Make the docs
+# We make assumptions about the location for the docs
+make docs
+
+# $BUILD_DIR contains the raw generated markdown for our documentation
+pushd "${BUILD_DIR}" || exit 1
+mkdir -p "${DOCS_DIR}"
+cp -r docs/* "${DOCS_DIR}"/
+cp -r mkdocs.yml "${DOCS_DIR}"
+
+# Upload any new documentation
+echo "Preparing to upload generated markdown content from ${GEN_MD}"
+echo "Git fiddling commences..."
+pushd "${GEN_MD}" || exit 1
+echo "Creating a branch for generated documentation..."
+branch_name="${PACKAGE_NAME}-${TAG}"
+git checkout -b "${branch_name}"
+echo "Adding content..."
+git add .
+git commit -m "Add docs for package: ${PACKAGE_NAME} version: ${TAG}"
+echo "Uploading new generated markdown content..."
+git push --set-upstream origin "${branch_name}"
+echo "Generated markdown content has been uploaded!"
+popd || exit 1
+
+# Create a PR
+echo "Preparing to create a pull request..."
+jsontemplate="
+{
+  \"title\":\$title,
+  \"head\":\$incoming_repo_and_branch,
+  \"base\":\"master\"
+}
+"
+
+json=$(jq -n \
+--arg title "${PACKAGE_NAME} ${TAG}" \
+--arg incoming_repo_and_branch "${GITHUB_USER}:${branch_name}" \
+"${jsontemplate}")
+
+
+echo "Curling..."
+result=$(curl -X POST \
+  https://api.github.com/repos/ponylang/main.actor-package-markdown/pulls \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "${GITHUB_USER}:${GITHUB_TOKEN}" \
+  --data "${json}")
+
+rslt_scan=$(echo "${result}" | jq -r '.id')
+if [ "$rslt_scan" != null ]
+then
+  echo "PR successfully created!"
+else
+  echo "Unable to create PR, here's the curl output..."
+  echo "${result}"
+  exit 1
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,24 @@ jobs:
       - zulip/status:
           fail_only: true
 
+  cut-release:
+    docker:
+      - image: ponylang/main.actor-ci:standard
+    steps:
+      - checkout
+      - run: bash .ci-scripts/release.bash "$CIRCLE_TAG" "$GITHUB_TOKEN"
+
+  generate-documentation-pr-for-main-dot-actor:
+    docker:
+      - image: ponylang/main.actor-ci:standard
+    steps:
+      - checkout
+      - run: bash .ci-scripts/upload-release-documentation-to-main-actor.bash "$CIRCLE_TAG" "$GITHUB_TOKEN"
+
 workflows:
   version: 2.1
-  commit:
+
+  on-every-commit:
     jobs:
       - verify-changelog:
           context: org-global
@@ -64,7 +79,27 @@ workflows:
       - debug-vs-ponyc-release:
           context: org-global
 
-  nightly:
+  create-release:
+    jobs:
+      - cut-release:
+          context: org-global
+          filters:
+            tags:
+              only: /^release-\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+
+  on-release-being-tagged:
+    jobs:
+      - generate-documentation-pr-for-main-dot-actor:
+          context: org-global
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+
+  daily-check-for-breakage:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -74,6 +109,5 @@ workflows:
     jobs:
       - release-vs-ponyc-master:
           context: org-global
-
       - debug-vs-ponyc-master:
           context: org-global

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,18 @@ ifdef config
 	endif
 endif
 
-ifeq ($(config),release)
-	PONYC = ${COMPILE_WITH}
+ifeq ($(ssl), 1.1.x)
+  SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+  SSL = -Dopenssl_0.9.0
 else
-	PONYC = ${COMPILE_WITH} --debug
+  $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+ifeq ($(config),release)
+	PONYC = ${COMPILE_WITH} ${SSL}
+else
+	PONYC = ${COMPILE_WITH} ${SSL} --debug
 endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name \*.pony)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 config ?= release
 
+PACKAGE := crypto
+COMPILE_WITH := ponyc
+
 BUILD_DIR ?= build/$(config)
-SRC_DIR ?= crypto
-tests_binary := $(BUILD_DIR)/crypto
+SRC_DIR ?= $(PACKAGE)
+tests_binary := $(BUILD_DIR)/$(PACKAGE)
+docs_dir := build/$(PACKAGE)-docs
 
 ifdef config
 	ifeq (,$(filter $(config),debug release))
@@ -11,9 +15,9 @@ ifdef config
 endif
 
 ifeq ($(config),release)
-	PONYC = ponyc
+	PONYC = ${COMPILE_WITH}
 else
-	PONYC = ponyc --debug
+	PONYC = ${COMPILE_WITH} --debug
 endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name \*.pony)
@@ -34,6 +38,12 @@ clean:
 
 realclean:
 	rm -rf build
+
+$(docs_dir): $(GEN_FILES) $(SOURCE_FILES)
+	rm -rf $(docs_dir)
+	${PONYC} --docs-public --pass=docs --output build $(SRC_DIR)
+
+docs: $(docs_dir)
 
 TAGS:
 	ctags --recurse=yes $(SRC_DIR)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -20,7 +20,7 @@ Before getting started, you will need a number for the version that you will be 
 Please note that the release script was written with the assumption that you are using a clone of the `{REPO}` repo. You have to be using a clone rather than a fork. Further, due to how git works, you need to make sure that both your `master` branch is up-to-date. It is advised to your do this but making a fresh clone of the `{REPO}` repo from which you will release. For example:
 
 ```bash
-git clone git@github.com:{USERNAME}/{REPO}.git {REPO}-release-clean
+git clone git@github.com:{REPO_OWNER}/{REPO}.git {REPO}-release-clean
 cd {REPO}-release-clean
 ```
 
@@ -42,7 +42,7 @@ bash release.bash seantallen 9999998gk48888ddd78a9fd12345a12870987uk \
 Navigate to the GitHub page for the release you just created. It will be something like:
 
 ```
-https://github.com/{USERNAME}/{REPO}/releases/tag/0.3.1
+https://github.com/{REPO_OWNER}/{REPO}/releases/tag/0.3.1
 ```
 
 Copy the url to the page. You'll need it for the next two steps.

--- a/release.bash
+++ b/release.bash
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-USERNAME=ponylang
+REPO_OWNER=ponylang
 REPONAME=crypto
 
 verify_args() {
@@ -91,7 +91,7 @@ json=$(jq -n \
 --arg body "$body" \
 "${jsontemplate}")
 
-curl -X POST "https://api.github.com/repos/${USERNAME}/${REPO}/releases" \
+curl -X POST "https://api.github.com/repos/${REPO_OWNER}/${REPO}/releases" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "${ghuser}:${ghtoken}" \
   --data "${json}"

--- a/release.bash
+++ b/release.bash
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 
 REPO_OWNER=ponylang
-REPONAME=crypto
+REPO_NAME=crypto
 
 verify_args() {
   echo "Cutting a release for version $version with commit $commit"
@@ -91,7 +91,7 @@ json=$(jq -n \
 --arg body "$body" \
 "${jsontemplate}")
 
-curl -X POST "https://api.github.com/repos/${REPO_OWNER}/${REPO}/releases" \
+curl -X POST "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "${ghuser}:${ghtoken}" \
   --data "${json}"


### PR DESCRIPTION
This is the code to add a fully automated release process to the crypto library. It's easier to see what is involved in this PR than the incremental way I added it to the library-project-starter.

Roughly it does the following:

- user tags HEAD of their master as `release-x.y.z` when they are ready to release
- CircleCI kicks off and runs the .ci-scripts/release.bash script as part of its work it creates a new tag 'x.y.z' that gets pushed
- CircleCI gets kicked off my new commits and tag from the previous step
- CircleCI generates documentation using `upload-release-documentation-to-main-actor.bash` which creates the documentation for the release and opens a PR against the repo that the generated-documentation that main.actor uses is stored.

Please let me know here what variables have confusing names, where you would want more comments etc so I can update both this PR and the library-project-starter so we can finalize this and the crypto library can be the first release.

Still to do:

- Update the "release process" document to detail how to do this simplified release.
- Delete old `release.bash` that is triggered by hand on a local machine and does far less.

After this is merged and before first release I might add:

- Automating the announcement of a new release to the Zulip announcements stream
- Automating adding a note about the release to LWIP issue