### PR TITLE
Improve performance of constant time comparison

### DIFF
--- a/crypto/constant_time_compare.pony
+++ b/crypto/constant_time_compare.pony
@@ -1,5 +1,5 @@
 primitive ConstantTimeCompare
-  fun apply(xs: ByteSeq, ys: ByteSeq): Bool =>
+  fun apply[S: ByteSeq box = ByteSeq box](xs: S, ys: S): Bool =>
   """
   Return true if the two ByteSeqs, xs and ys, have equal contents. The time
   taken is independent of the contents.


### PR DESCRIPTION
With this change, we access the arguments as concrete types rather
than through an interface. This is a non-breaking change and should
improve performance at runtime.

Closes #4