### PR TITLE
Use Corral in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
   else ifeq ($(ssl), 0.9.0)
 	  SSL = -Dopenssl_0.9.0
   else
-    $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+    $(error Unknown SSL version "$(ssl)". Must set using 'ssl=1.1.x' or 'ssl=0.9.0')
   endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 config ?= release
 
 PACKAGE := crypto
-COMPILE_WITH := ponyc
+GET_DEPENDENCIES_WITH := corral fetch
+CLEAN_DEPENDENCIES_WITH := corral clean
+COMPILE_WITH := corral run -- ponyc
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR ?= $(PACKAGE)
@@ -42,6 +44,7 @@ unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
 
 $(tests_binary): $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) $(SSL) -o $(BUILD_DIR) $(SRC_DIR)
 
 build-examples: $(EXAMPLES_BINARIES)
@@ -51,6 +54,7 @@ $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) |
 	$(PONYC) -o $(BUILD_DIR) $(EXAMPLES_DIR)/$*
 
 clean:
+	$(CLEAN_DEPENDENCIES_WITH)
 	rm -rf $(BUILD_DIR)
 
 $(docs_dir): $(GEN_FILES) $(SOURCE_FILES)


### PR DESCRIPTION
Updates Makefile to use corral instead of ponyc directly. Also adds
implements getting and cleaning dependencies with corral.

Fixes #19 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>