### PR TITLE
Add libressl and openssl 1.1.x as test targets

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -5,12 +5,22 @@ on:
     - cron: "0 3 * * *"
 
 jobs:
-  vs-ponyc-latest:
-    name: Test against ponyc master
+  test-libressl-vs-ponyc-latest:
+    name: libressl with ponyc master
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test
         run: make test config=debug ssl=0.9.0
+
+  test-openssl-1_1_x-vs-ponyc-latest:
+    name: openssl 1.1.x with ponyc master
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.x:latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Test
+        run: make test config=debug ssl=1.1.x

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,12 +13,22 @@ jobs:
       - name: Verify CHANGELOG
         run: changelog-tool verify
 
-  vs-ponyc-release:
-    name: Test against recent ponyc release
+  test-libressl-vs-ponyc-release:
+    name: libressl with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl:release
     steps:
       - uses: actions/checkout@v1
       - name: Test
         run: make test config=debug ssl=0.9.0
+
+  test-openssl-1_1_x-vs-ponyc-release:
+    name: openssl 1.1.x with most recent ponyc release
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.x:release
+    steps:
+      - uses: actions/checkout@v1
+      - name: Test
+        run: make test config=debug ssl=1.1.x


### PR DESCRIPTION
Previously we were only testing with libressl.

This partially closes #29. We need to decide if we want to continue testing
with openssl 0.9.x explicitly. There is a conversation about that in issue #30.