### PR TITLE
Move to new libressl testing environment

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -5,11 +5,11 @@ on:
     - cron: "0 3 * * *"
 
 jobs:
-  test-libressl-vs-ponyc-latest:
-    name: libressl with ponyc master
+  test-libressl-3_1_2-vs-ponyc-latest:
+    name: libressl 3.1.2 with ponyc master
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Verify CHANGELOG
         run: changelog-tool verify
 
-  test-libressl-vs-ponyc-release:
-    name: libressl with most recent ponyc release
+  test-libressl-3_1_2-vs-ponyc-release:
+    name: libressl 3.1.2 with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:release
     steps:
       - uses: actions/checkout@v1
       - name: Test


### PR DESCRIPTION
We are now building libressl from source from a known package rather
than using whatever the system happens to install in our particular
container.