### PR TITLE
Switch away from main-actor for documentation hosting

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,9 +1,7 @@
-name: Release
+name: Manually generate documentation
 
 on:
-  push:
-    tags:
-      - \d+.\d+.\d+
+  workflow_dispatch
 
 jobs:
   generate-documentation:
@@ -17,21 +15,6 @@ jobs:
           site_url: "https://ponylang.github.io/crypto/"
           library_name: "crypto"
           docs_build_dir: "build/crypto-docs"
-          git_user_name: "Ponylang Main Bot"
-          git_user_email: "ponylang.main@gmail.com"
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-
-  trigger-release-announcement:
-    name: Trigger release announcement
-    runs-on: ubuntu-latest
-    needs: [generate-documentation]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Trigger
-        uses: ponylang/release-bot-action@0.3.3
-        with:
-          step: trigger-release-announcement
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
         env:

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ sudo zypper install libopenssl-devel
 If you use [Corral](https://github.com/ponylang/corral) to include this package as dependency of a project, Corral will download and build LibreSSL for you the first time you run `corral fetch`.  Otherwise, before using this package, you must run `.\make.ps1 libs` in its base directory to download and build LibreSSL for Windows. In both cases, you will need CMake (3.15 or higher) and 7Zip (`7z.exe`) in your `PATH`; and Visual Studio 2019 (or the Visual C++ Build Tools 2019) installed in your system.
 
 You should pass `--define openssl_0.9.0` to Ponyc when using this package on Windows.
+
+## API Documentation
+
+[https://ponylang.github.io/crypto/](https://ponylang.github.io/crypto/)


### PR DESCRIPTION
We're moving to using the library-documentation-action. crypto can
work with version 0.1.0 of the action as it has no dependencies other
than the standard library.