### PR TITLE
Free the underlying digest context on OpenSSL 0.9.0

### DIFF
--- a/.release-notes/55.md
+++ b/.release-notes/55.md
@@ -1,0 +1,3 @@
+## Free the underlying digest context on OpenSSL 0.9.0
+
+The code under OpenSSL 0.9.0 was using EVP_MD_CTX_cleanup, which doesn't free the underlying context. This means that the memory allocated with EVP_MD_CTX_create would never be freed, leading to a potential memory leak. This is now fixed by using the appropriate function, EVP_MD_CTX_destroy.

--- a/crypto/digest.pony
+++ b/crypto/digest.pony
@@ -157,7 +157,7 @@ class Digest
       ifdef "openssl_1.1.x" then
         @EVP_MD_CTX_free[None](_ctx)
       else
-        @EVP_MD_CTX_cleanup[None](_ctx)
+        @EVP_MD_CTX_destroy[None](_ctx)
       end
       let h = (consume digest).array()
       _hash = h


### PR DESCRIPTION
The code under OpenSSL 0.9.0 was using EVP_MD_CTX_cleanup, which doesn't
free the underlying context. This means that the memory allocated with
EVP_MD_CTX_create would never be freed, leading to a potential memory
leak.

Fixes #54 