### PR TITLE
Updates for libs build on Windows

### DIFF
--- a/.release-notes/68.md
+++ b/.release-notes/68.md
@@ -1,3 +1,4 @@
-## Remove hard-coded Visual Studio version for building Windows libs
+## Updates for libs build on Windows
 
-Building on Windows requires Visual Studio to build required libraries; we removed a hard-coded Visual Studio version from the build script so that it can be built with more versions of Visual Studio.
+We removed a hard-coded Visual Studio version from the build script so that it can be built with more versions of Visual Studio.
+We upgraded the LibreSSL version to 3.5.0.

--- a/.release-notes/68.md
+++ b/.release-notes/68.md
@@ -1,0 +1,3 @@
+## Remove hard-coded Visual Studio version for building Windows libs
+
+Building on Windows requires Visual Studio to build required libraries; we removed a hard-coded Visual Studio version from the build script so that it can be built with more versions of Visual Studio.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sudo zypper install libopenssl-devel
 
 ### Installing on Windows
 
-If you use [Corral](https://github.com/ponylang/corral) to include this package as dependency of a project, Corral will download and build LibreSSL for you the first time you run `corral fetch`.  Otherwise, before using this package, you must run `.\make.ps1 libs` in its base directory to download and build LibreSSL for Windows. In both cases, you will need CMake (3.15 or higher) and 7Zip (`7z.exe`) in your `PATH`; and Visual Studio 2019 (or the Visual C++ Build Tools 2019) installed in your system.
+If you use [Corral](https://github.com/ponylang/corral) to include this package as dependency of a project, Corral will download and build LibreSSL for you the first time you run `corral fetch`.  Otherwise, before using this package, you must run `.\make.ps1 libs` in its base directory to download and build LibreSSL for Windows. In both cases, you will need CMake (3.15 or higher) and 7Zip (`7z.exe`) in your `PATH`; and Visual Studio 2017 or later (or the Visual C++ Build Tools) installed in your system.
 
 You should pass `--define openssl_0.9.0` to Ponyc when using this package on Windows.
 

--- a/crypto/digest.pony
+++ b/crypto/digest.pony
@@ -1,5 +1,6 @@
 use "path:/usr/local/opt/libressl/lib" if osx
 use "lib:crypto"
+use "lib:bcrypt" if windows
 
 use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x"
 use @EVP_MD_CTX_create[Pointer[_EVPCTX]]() if not "openssl_1.1.x"
@@ -43,7 +44,7 @@ class Digest
       _ctx = @EVP_MD_CTX_create()
     end
     @EVP_DigestInit_ex(_ctx, @EVP_md4(), USize(0))
-    
+
   new md5() =>
     """
     Use the MD5 algorithm to calculate the hash.

--- a/make.ps1
+++ b/make.ps1
@@ -145,7 +145,7 @@ function BuildTest
 
 function BuildLibs
 {
-  $libreSsl = "libressl-3.2.5"
+  $libreSsl = "libressl-3.5.0"
 
   if (-not (Test-Path "$rootDir/crypto.lib"))
   {
@@ -177,7 +177,7 @@ function BuildLibs
     }
 
     # copy to the root dir (i.e. PONYPATH) for linking
-    Copy-Item -Force -Path "$libsDir/lib/crypto-46.lib" -Destination "$rootDir/crypto.lib"
+    Copy-Item -Force -Path "$libsDir/lib/crypto-49.lib" -Destination "$rootDir/crypto.lib"
   }
 }
 

--- a/make.ps1
+++ b/make.ps1
@@ -169,7 +169,7 @@ function BuildLibs
     {
       Push-Location $libreSslSrc
       (Get-Content "$libreSslSrc\CMakeLists.txt").replace('add_definitions(-Dinline=__inline)', "add_definitions(-Dinline=__inline)`nadd_definitions(-DPATH_MAX=255)") | Set-Content "$libreSslSrc\CMakeLists.txt"
-      cmake.exe $libreSslSrc -G "Visual Studio 16 2019" -Thost=x64 -A x64 -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE="Release"
+      cmake.exe $libreSslSrc -Thost=x64 -A x64 -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE="Release"
       if ($LastExitCode -ne 0) { Pop-Location; throw "Error configuring $libreSsl" }
       cmake.exe --build . --target install --config Release
       if ($LastExitCode -ne 0) { Pop-Location; throw "Error building $libreSsl" }


### PR DESCRIPTION
We removed a hard-coded Visual Studio version from the build script so that it can be built with more versions of Visual Studio.
We upgraded the LibreSSL version to 3.5.0.