### PR TITLE
Add path to Homebrew's LibreSSL on ARM macOS

### DIFF
--- a/.release-notes/73.md
+++ b/.release-notes/73.md
@@ -1,0 +1,3 @@
+## Add path to Homebrew's LibreSSL on ARM macOS
+
+With the release of ponyc 0.45.0, Apple Silicon is now a supported platform, which means that the default install location of Homebrew formulas has changed. This release of crypto allows one to build the library without using the ponyc `--path` option to include LibreSSL.

--- a/crypto/digest.pony
+++ b/crypto/digest.pony
@@ -1,4 +1,5 @@
-use "path:/usr/local/opt/libressl/lib" if osx
+use "path:/usr/local/opt/libressl/lib" if osx and x86
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 use "lib:bcrypt" if windows
 

--- a/crypto/hash_fn.pony
+++ b/crypto/hash_fn.pony
@@ -1,4 +1,5 @@
-use "path:/usr/local/opt/libressl/lib" if osx
+use "path:/usr/local/opt/libressl/lib" if osx and x86
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 
 use @MD4[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])


### PR DESCRIPTION
Homebrew moved from installing packages under `/usr/local` to
`/opt/homebrew` for Apple Silicon processors.

Another popular alternative to Homebrew, MacPorts, is already covered by
including `/opt/local/lib`.

---

This is the same as https://github.com/ponylang/net_ssl/pull/54, and is the easiest way to fix link errors on ponyup. 