### PR TITLE
Remove `md4` constructor from `Digest`

### DIFF
--- a/.release-notes/remove-md4-digest.md
+++ b/.release-notes/remove-md4-digest.md
@@ -1,0 +1,5 @@
+## Remove `md4` constructor from `Digest`
+
+With the introduction of OpenSSL 3, the OpenSSL developers have moved MD4 to a "legacy provider". What this means is that via the mechanism that the `Digest` class uses, we can no longer cleanly support MD4 without adding bloat that would impact on the usability of the other algorithms supported by `Digest`.
+
+The `md4` constructor has been removed from `Digest`. Note that an alternate method of doing `md4` hashing is still available via the `MD4` primitive.

--- a/crypto/_test.pony
+++ b/crypto/_test.pony
@@ -106,13 +106,6 @@ class \nodoc\ iso _TestDigest is UnitTest
   fun name(): String => "crypto/Digest"
 
   fun apply(h: TestHelper) ? =>
-    let md4 = Digest.md4()
-    md4.append("message1")?
-    md4.append("message2")?
-    h.assert_eq[String](
-      "6f299e11a64b5983b932ae9a682f0379",
-      ToHexString(md4.final()))
-
     let md5 = Digest.md5()
     md5.append("message1")?
     md5.append("message2")?

--- a/crypto/digest.pony
+++ b/crypto/digest.pony
@@ -11,7 +11,6 @@ use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: 
 use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x"
 use @EVP_MD_CTX_destroy[None](ctx: Pointer[_EVPCTX]) if not "openssl_1.1.x"
 
-use @EVP_md4[Pointer[_EVPMD]]()
 use @EVP_md5[Pointer[_EVPMD]]()
 use @EVP_ripemd160[Pointer[_EVPMD]]()
 use @EVP_sha1[Pointer[_EVPMD]]()
@@ -33,18 +32,6 @@ class Digest
   let _digest_size: USize
   let _ctx: Pointer[_EVPCTX]
   var _hash: (Array[U8] val | None) = None
-
-  new md4() =>
-    """
-    Use the MD4 algorithm to calculate the hash.
-    """
-    _digest_size = 16
-    ifdef "openssl_1.1.x" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      _ctx = @EVP_MD_CTX_create()
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_md4(), USize(0))
 
   new md5() =>
     """


### PR DESCRIPTION
With the introduction of OpenSSL 3, the OpenSSL developers have moved MD4 to a "legacy provider". What this means is that via the mechanism that the `Digest` class uses, we can no longer cleanly support MD4 without adding bloat that would impact on the usability of the other algorithms supported by `Digest`.

This commit removes the `md4` constructor from `Digest`. An alternate method of doing `md4` hashing is still available via the `MD4` primitive.

Closes #77